### PR TITLE
add Plack::ServerTiming

### DIFF
--- a/lib/Plack/ServerTiming.pm
+++ b/lib/Plack/ServerTiming.pm
@@ -1,0 +1,65 @@
+package Plack::ServerTiming;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $env) = @_;
+    return bless {
+        env => $env,
+    } => $class;
+}
+
+sub record_timing {
+    my ($self, $name, $field) = @_;
+    $field ||= {};
+
+    push @{ $self->{env}->{'psgix.server-timing'} } => [$name, $field];
+}
+
+1;
+__END__
+
+=pod
+
+=encoding utf-8
+
+=head1 NAME
+
+Plack::ServerTiming - Frontend for Plack::Middleware::ServerTiming
+
+=head1 SYNOPSIS
+
+    use Plack::ServerTiming;
+
+    builder {
+        enable 'ServerTiming';
+        sub {
+            my $env = shift;
+            my $t = Plack::ServerTiming->new($env);
+            sleep 1;
+            $t->record_timing('miss');
+            $t->record_timing(sleep => {dur => 1000, desc => 'Sleep one second...'});
+            [200, ['Content-Type','text/html'], ["OK"]];
+        };
+    };
+
+=head1 DESCRIPTION
+
+This module provides high level API for L<Plack::Middleware::ServerTiming>.
+
+=head1 SEE ALSO
+
+L<Plack::Middleware::ServerTiming>
+
+=head1 LICENSE
+
+Copyright (C) Takumi Akiyama.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=head1 AUTHOR
+
+Takumi Akiyama E<lt>t.akiym@gmail.comE<gt>
+
+=cut

--- a/t/00_compile.t
+++ b/t/00_compile.t
@@ -2,6 +2,7 @@ use strict;
 use Test::More 0.98;
 
 use_ok $_ for qw(
+    Plack::ServerTiming
     Plack::Middleware::ServerTiming
 );
 

--- a/t/03_frontend.t
+++ b/t/03_frontend.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use Plack::Test;
+use Test::More;
+use HTTP::Request::Common;
+
+use Plack::Builder;
+use Plack::ServerTiming;
+
+my $app = builder {
+    enable "ServerTiming";
+    sub {
+        my $env = shift;
+        my $t = Plack::ServerTiming->new($env);
+        $t->record_timing('miss');
+        $t->record_timing('db', {dur  => 53});
+        $t->record_timing('dc', {desc => 'atl'});
+        $t->record_timing('da', {dur => 99, desc => 'A B C'});
+        return [200, ['Content-Type'=>'text/html'], ["Hello"]];
+    };
+};
+
+test_psgi $app, sub {
+    my $cb = shift;
+    my $res = $cb->(GET "/");
+
+    is $res->header('Server-Timing'), 'miss, db;dur=53, dc;desc=atl, da;dur=99;desc="A B C"';
+};
+
+done_testing;


### PR DESCRIPTION
Likes Plack::Session

```perl
use Plack::ServerTiming;

builder {
    enable 'ServerTiming';
    sub {
        my $env = shift;
        my $t = Plack::ServerTiming->new($env);
        sleep 1;
        $t->record_timing('miss');
        $t->record_timing(sleep => {dur => 1000, desc => 'Sleep one second...'});
        [200, ['Content-Type','text/html'], ["OK"]];
    };
};
```

I think almost Plack application engineers don't like to edit `$env` in an application directly.
Hou do you think?